### PR TITLE
Support Windows line endings

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ var CommentExtractor = (function () {
       blockPattern =
           '^[ \\t]*' +
           escapeStringRegexp(blockCommentStyle) +
-          '((?:[^*]|[\\r\\n]|(?:\\*+(?:[^*/]|[\\r\\n])))*)(\\*+)\\/';
+          '((?:[^*]|\\n|(?:\\*+(?:[^*/]|\\n)))*)(\\*+)\\/';
     }
 
 
@@ -106,7 +106,7 @@ var CommentExtractor = (function () {
   }
 
   var cleanBlockComment = function (comment) {
-    var removeFirstLine = comment.replace(/^.*?[\r\n]+|[\r\n].*?$/g, '');
+    var removeFirstLine = comment.replace(/^.*?\n+|\n.*?$/g, '');
     var removeLeadingStar = removeFirstLine.replace(/^[ \t]*\*/gm, '');
     return stripIndent(removeLeadingStar).split(/\n/);
   };
@@ -131,6 +131,11 @@ var CommentExtractor = (function () {
       type : type
     };
   };
+
+  var unifyLineEndings = function (code) {
+    return code.replace(/\r\n?|\n/g, '\n');
+  };
+
 
   function CommentExtractor (parseContext, opts) {
     this.parseContext = parseContext;
@@ -165,6 +170,8 @@ var CommentExtractor = (function () {
    * @return {Array} Array of comment object like `{ lines : [array of comment lines], context : [result of contextParser] }`
    */
   CommentExtractor.prototype.extract = function (code) {
+    code = unifyLineEndings(code);
+
     var match;
     var comments = [];
 

--- a/test/fixtures/crlf.test.scss
+++ b/test/fixtures/crlf.test.scss
@@ -1,0 +1,9 @@
+/**
+ * Block comment with CRLF.
+ * With multiple lines.
+ */
+
+///
+/// Comment with CRLF.
+/// It have multiple lines in a single comment.
+///

--- a/test/test.js
+++ b/test/test.js
@@ -501,6 +501,24 @@ describe('CDocParser', function(){
 
       });
 
+      describe('File with CRLF', function(){
+        it('should extract comments', function (){
+          var comments = getCommentsFrom('crlf.test.scss');
+          assert.equal(comments.length, 2);
+          assert.deepEqual(comments[0].lines, [
+            'Block comment with CRLF.',
+            'With multiple lines.'
+          ]);
+          assert.deepEqual(comments[0].commentRange, { start: 1, end: 4 });
+          assert.deepEqual(comments[1].lines, [
+            '',
+            'Comment with CRLF.',
+            'It have multiple lines in a single comment.',
+            ''
+          ]);
+          assert.deepEqual(comments[1].commentRange, { start: 6, end: 9 });
+        });
+      });
 
     });
   });


### PR DESCRIPTION
This is done by converting input code to Unix line endings. I also removed specific code to handle MacOS line endings.

Reference issue: SassDoc/sassdoc#327